### PR TITLE
Add auto label on merged pr

### DIFF
--- a/.github/workflows/auto-label-pr-merge.yml
+++ b/.github/workflows/auto-label-pr-merge.yml
@@ -1,0 +1,28 @@
+name: Auto Label PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  label_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Label Merged PR
+        if: github.event.pull_request.merged == true
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Add labels to merged pull requests
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['gssoc-ext', 'hacktoberfest-accepted']
+            });


### PR DESCRIPTION
**Purpose**: This PR adds automatic labeling for merged pull requests to streamline project management and enhance visibility.

**Labels Added:** Upon merging, the following labels will be automatically assigned:
- gssoc-ext
- hacktoberfest-accepted

**Benefit:** This automation will help in categorizing contributions efficiently and recognizing participants for their efforts.

Hey @sanjay-kv please review the PR
